### PR TITLE
setup: change description (was that of sphinx-copybutton)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ version = line.split(" = ")[-1].strip('"')
 setup(
     name="sphinx-thebe",
     version=version,
-    description="Add a copy button to each of your code cells.",
+    description="Integrate interactive code blocks into your documentation with Thebelab and Binder.",
     long_description=readme_text,
     long_description_content_type="text/markdown",
     author="Executable Book Project",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ version = line.split(" = ")[-1].strip('"')
 setup(
     name="sphinx-thebe",
     version=version,
-    description="Integrate interactive code blocks into your documentation with Thebelab and Binder.",
+    description="Integrate interactive code blocks into your documentation with Thebe and Binder.",
     long_description=readme_text,
     long_description_content_type="text/markdown",
     author="Executable Book Project",


### PR DESCRIPTION
- The description metadata in setup.py is wrong, it seems to have not
  been changed from sphinx-copybutton.
- Noticed when searching on PyPI