### PR TITLE
🐛 FIX: Remove not imported top-level package docutils

### DIFF
--- a/sphinx_thebe/__init__.py
+++ b/sphinx_thebe/__init__.py
@@ -1,11 +1,12 @@
 """A small sphinx extension to add "copy" buttons to code blocks."""
+
+import json
 import os
-from sphinx.util import logging
+from pathlib import Path
+
 from docutils.parsers.rst import Directive, directives
 from docutils import nodes
-import json
-
-from pathlib import Path
+from sphinx.util import logging
 
 __version__ = "0.0.8dev0"
 
@@ -179,7 +180,7 @@ def visit_element_html(self, node):
 
 # Used for nodes that do not need to be rendered
 def skip(self, node):
-    raise docutils.nodes.SkipNode
+    raise nodes.SkipNode
 
 
 def setup(app):


### PR DESCRIPTION
This should help fix build issues on https://readthedocs.io like:

```
Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/xyz-spaces-python/envs/latest/lib/python3.7/site-packages/sphinx_thebe/__init__.py", line 182, in skip
    raise docutils.nodes.SkipNode
NameError: name 'docutils' is not defined
```

Plus applied some isort-like manual grouping of imports.
