### PR TITLE
ENH: Lazy load thebe javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation](https://readthedocs.org/projects/sphinx-thebe/badge/?version=latest)](https://sphinx-thebe.readthedocs.io/en/latest/?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/sphinx-thebe.svg)](https://pypi.org/project/sphinx-thebe)
 
-Integrate interactive code blocks into your documentation with Thebelab and Binder.
+Integrate interactive code blocks into your documentation with Thebe and Binder.
 
 See [the sphinx-thebe documentation](https://sphinx-thebe.readthedocs.io/en/latest/) for more details!
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,8 @@ thebe_config = {
     # "selector": ".thebe",
     # "selector_input": ,
     # "selector_output": ,
-    # "codemirror-theme": "blackboard"  # Doesn't currently work
+    # "codemirror-theme": "blackboard",  # Doesn't currently work
+    # "always_load": True,  # To load thebe on every page
 }
 
 myst_enable_extensions = ["colon_fence"]
@@ -86,6 +87,7 @@ pygments_style = "sphinx"
 # a list of builtin themes.
 #
 html_theme = "sphinx_book_theme"
+html_title = "sphinx-thebe"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -202,15 +202,16 @@ thebe_config = {
 See [the CodeMirror theme demo](https://codemirror.net/demo/theme.html) for a list
 of themes that you can use, and what they look like.
 
-## Only load JS on certain pages
+## Load `thebe` automatically on all pages
 
-By default, `sphinx-thebe` will load the JS/CSS from `thebe` on all of your documentation's pages.
-Alternatively, you may load `thebe` only on pages that use the `thebe-button` directive.
-To do so, use the following configuration:
+By default, `sphinx-thebe` will lazily load the JS/CSS from `thebe` when the `sphinx-thebe` initialization button is pressed.
+This means that no Javascript is loaded until a person explicitly tries to start thebe, which reduces page load times.
+
+If you want `thebe` to be loaded on every page, in an "eager" fashion, you may do so with the following configuration:
 
 ```python
 thebe_config = {
-   "always_load": False
+   "always_load": True
 }
 ```
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -218,7 +218,7 @@ thebe_config = {
 
 Here's a reference of all of the configuration values avialable to `sphinx-thebe`.
 Many of these eventually make their was into the `thebe` configuration. You can
-find a [reference for `thebe` configuration here](https://thebelab.readthedocs.io/en/latest/config_reference.html).
+find a [reference for `thebe` configuration here](https://thebe.readthedocs.io/en/latest/config_reference.html).
 
 ```python
 thebe_config = {

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,7 @@
 :alt: PyPi page
 ```
 
-Make your code cells interactive with a kernel provided by [Thebe](http://thebelab.readthedocs.org/)
-and [Binder](https://mybinder.org).
+Make your code cells interactive with a kernel provided by [Thebe](http://thebe.readthedocs.org/) and [Binder](https://mybinder.org).
 
 For example, click the button below. Notice that the code block beneath becomes
 editable and runnable!
@@ -29,7 +28,7 @@ print("hi")
 See [](use.md) for more information about what you can do with `sphinx-thebe`.
 
 ```{note}
-This package is a Sphinx wrapper around the excellent [thebe project](http://thebelab.readthedocs.org/),
+This package is a Sphinx wrapper around the excellent [thebe project](http://thebe.readthedocs.org/),
 a javascript tool to convert static code cells into interactive cells backed
 by a kernel.
 ```

--- a/sphinx_thebe/__init__.py
+++ b/sphinx_thebe/__init__.py
@@ -70,8 +70,9 @@ def init_thebe_core(app, env, docnames):
     config_thebe = app.config["thebe_config"]
 
     # Add configuration variables
+    THEBE_JS_URL = f"https://unpkg.com/thebe@{THEBE_VERSION}/lib/index.js"
     thebe_config = f"""\
-        const THEBE_VERSION = "{ THEBE_VERSION }"
+        const THEBE_JS_URL = "{ THEBE_JS_URL }"
         const thebe_selector = "{ app.config.thebe_config['selector'] }"
         const thebe_selector_input = "{ app.config.thebe_config['selector_input'] }"
         const thebe_selector_output = "{ app.config.thebe_config['selector_output'] }"
@@ -81,8 +82,7 @@ def init_thebe_core(app, env, docnames):
 
     if config_thebe.get("always_load") is True:
         # If we've got `always load` on, then load thebe on every page.
-        thebejs = f"https://unpkg.com/thebe@{THEBE_VERSION}/lib/index.js"
-        app.add_js_file(thebejs)
+        app.add_js_file(THEBE_JS_URL, **{"async": "async"})
 
 def update_thebe_context(app, doctree, docname):
     """Add thebe config nodes to this doctree using page-dependent information."""

--- a/sphinx_thebe/__init__.py
+++ b/sphinx_thebe/__init__.py
@@ -58,25 +58,24 @@ def _do_load_thebe(doctree, config_thebe):
 
 
 def init_thebe_core(app, pagename, templatename, context, doctree):
-    """Load thebe assets if there's a thebe button on this page."""
+    """Load thebe assets if there's a thebe button on this page.
+    
+    We defer loading the `thebe` javascript bundle until bootstrap is called
+    in order to speed up page load times.
+    """
     config_thebe = app.config["thebe_config"]
     if not _do_load_thebe(doctree, config_thebe):
         return
 
-    # Add core libraries
-    opts = {"async": "async"}
-    app.add_js_file(
-        filename=f"https://unpkg.com/thebe@{THEBE_VERSION}/lib/index.js", **opts
-    )
-
     # Add configuration variables
     thebe_config = f"""
+        const THEBE_VERSION = "{ THEBE_VERSION }"
         const thebe_selector = "{ app.config.thebe_config['selector'] }"
         const thebe_selector_input = "{ app.config.thebe_config['selector_input'] }"
         const thebe_selector_output = "{ app.config.thebe_config['selector_output'] }"
     """
     app.add_js_file(None, body=thebe_config)
-    app.add_js_file(filename="sphinx-thebe.js", **opts)
+    app.add_js_file(filename="sphinx-thebe.js", **{"async": "async"})
 
 
 def update_thebe_context(app, doctree, docname):

--- a/sphinx_thebe/__init__.py
+++ b/sphinx_thebe/__init__.py
@@ -12,7 +12,7 @@ __version__ = "0.0.10"
 
 logger = logging.getLogger(__name__)
 
-THEBE_VERSION = "0.5.1"
+THEBE_VERSION = "0.8.2"
 
 
 def st_static_path(app):

--- a/sphinx_thebe/_static/sphinx-thebe.js
+++ b/sphinx_thebe/_static/sphinx-thebe.js
@@ -76,17 +76,27 @@ var modifyDOMForThebe = () => {
 }
 
 var initThebe = () => {
-    // Load thebe dynamically so we can reduce page size
-    console.log("[sphinx-thebe]: Loading thebe from CDN...");
-    const script = document.createElement('script');
-    script.src = `https://unpkg.com/thebe@${THEBE_VERSION}/lib/index.js`;
-    document.head.appendChild(script);
-    // Runs once the script has finished loading
-    script.addEventListener('load', () => {
+    // Load thebe dynamically if it's not already loaded
+    if (typeof thebelab === "undefined") {
+        console.log("[sphinx-thebe]: Loading thebe from CDN...");
+        $(".thebe-launch-button ").text("Loading thebe from CDN...");
+        const script = document.createElement('script');
+        script.src = `https://unpkg.com/thebe@${THEBE_VERSION}/lib/index.js`;
+        document.head.appendChild(script);
+
+        // Runs once the script has finished loading
+        script.addEventListener('load', () => {
+            console.log("[sphinx-thebe]: Finished loading thebe from CDN...");
+            configureThebe();
+            modifyDOMForThebe();
+            thebelab.bootstrap();
+        });
+    } else {
+        console.log("[sphinx-thebe]: thebe already loaded, not loading from CDN...");
         configureThebe();
         modifyDOMForThebe();
         thebelab.bootstrap();
-    });
+    }
 }
 
 // Helper function to munge the language name

--- a/sphinx_thebe/_static/sphinx-thebe.js
+++ b/sphinx_thebe/_static/sphinx-thebe.js
@@ -80,8 +80,9 @@ var initThebe = () => {
     if (typeof thebelab === "undefined") {
         console.log("[sphinx-thebe]: Loading thebe from CDN...");
         $(".thebe-launch-button ").text("Loading thebe from CDN...");
+
         const script = document.createElement('script');
-        script.src = `https://unpkg.com/thebe@${THEBE_VERSION}/lib/index.js`;
+        script.src = `${THEBE_JS_URL}`;
         document.head.appendChild(script);
 
         // Runs once the script has finished loading

--- a/sphinx_thebe/_static/sphinx-thebe.js
+++ b/sphinx_thebe/_static/sphinx-thebe.js
@@ -1,6 +1,79 @@
 /**
  * Add attributes to Thebe blocks to initialize thebe properly
  */
+var configureThebe = () => {
+    // Load thebe config in case we want to update it as some point
+    console.log("[sphinx-thebe]: Loading thebe config...");
+    thebe_config = $('script[type="text/x-thebe-config"]')[0]
+
+    // If we already detect a Thebe cell, don't re-run
+    if (document.querySelectorAll('div.thebe-cell').length > 0) {
+        return;
+    }
+
+    // Update thebe buttons with loading message
+    $(".thebe-launch-button").each((ii, button) => {
+        button.innerHTML = `
+        <div class="spinner">
+            <div class="rect1"></div>
+            <div class="rect2"></div>
+            <div class="rect3"></div>
+            <div class="rect4"></div>
+        </div>
+        <span class="loading-text"></span>`;
+    })
+
+    // Set thebe event hooks
+    var thebeStatus;
+    thebelab.on("status", function (evt, data) {
+        console.log("Status changed:", data.status, data.message);
+
+        $(".thebe-launch-button ")
+        .removeClass("thebe-status-" + thebeStatus)
+        .addClass("thebe-status-" + data.status)
+        .find(".loading-text").html("<span class='launch_msg'>Launching from mybinder.org: </span><span class='status'>" + data.status + "</span>");
+
+        // Now update our thebe status
+        thebeStatus = data.status;
+
+        // Find any cells with an initialization tag and ask thebe to run them when ready
+        if (data.status === "ready") {
+            var thebeInitCells = document.querySelectorAll('.thebe-init, .tag_thebe-init');
+            thebeInitCells.forEach((cell) => {
+                console.log("Initializing Thebe with cell: " + cell.id);
+                cell.querySelector('.thebelab-run-button').click();
+            });
+        }
+    });
+}
+
+/**
+ * Update the page DOM to use Thebe elements
+ */
+var modifyDOMForThebe = () => {
+    // Find all code cells, replace with Thebe interactive code cells
+    const codeCells = document.querySelectorAll(thebe_selector)
+    codeCells.forEach((codeCell, index) => {
+        const codeCellId = index => `codecell${index}`;
+        codeCell.id = codeCellId(index);
+        codeCellText = codeCell.querySelector(thebe_selector_input);
+        codeCellOutput = codeCell.querySelector(thebe_selector_output);
+
+        // Clean up the language to make it work w/ CodeMirror and add it to the cell
+        dataLanguage = detectLanguage(kernelName);
+
+        if (codeCellText) {
+            codeCellText.setAttribute('data-language', dataLanguage);
+            codeCellText.setAttribute('data-executable', 'true');
+
+            // If we had an output, insert it just after the `pre` cell
+            if (codeCellOutput) {
+                $(codeCellOutput).attr("data-output", "");
+                $(codeCellOutput).insertAfter(codeCellText);
+            }
+        }
+    });
+}
 
 var initThebe = () => {
     // Load thebe dynamically so we can reduce page size
@@ -8,79 +81,11 @@ var initThebe = () => {
     const script = document.createElement('script');
     script.src = `https://unpkg.com/thebe@${THEBE_VERSION}/lib/index.js`;
     document.head.appendChild(script);
-
     // Runs once the script has finished loading
     script.addEventListener('load', () => {
-        // Load thebe config in case we want to update it as some point
-        console.log("[sphinx-thebe]: Initializing thebe...");
-        thebe_config = $('script[type="text/x-thebe-config"]')[0]
-
-        // If we already detect a Thebe cell, don't re-run
-        if (document.querySelectorAll('div.thebe-cell').length > 0) {
-            return;
-        }
-
-        // Update thebe buttons with loading message
-        $(".thebe-launch-button").each((ii, button) => {
-            button.innerHTML = `
-            <div class="spinner">
-                <div class="rect1"></div>
-                <div class="rect2"></div>
-                <div class="rect3"></div>
-                <div class="rect4"></div>
-            </div>
-            <span class="loading-text"></span>`;
-        })
-
-        // Set thebe event hooks
-        var thebeStatus;
-        thebe.on("status", function (evt, data) {
-            console.log("Status changed:", data.status, data.message);
-
-            $(".thebe-launch-button ")
-            .removeClass("thebe-status-" + thebeStatus)
-            .addClass("thebe-status-" + data.status)
-            .find(".loading-text").html("<span class='launch_msg'>Launching from mybinder.org: </span><span class='status'>" + data.status + "</span>");
-
-            // Now update our thebe status
-            thebeStatus = data.status;
-
-            // Find any cells with an initialization tag and ask thebe to run them when ready
-            if (data.status === "ready") {
-                var thebeInitCells = document.querySelectorAll('.thebe-init, .tag_thebe-init');
-                thebeInitCells.forEach((cell) => {
-                    console.log("Initializing Thebe with cell: " + cell.id);
-                    cell.querySelector('.thebelab-run-button').click();
-                });
-            }
-        });
-
-
-        // Find all code cells, replace with Thebe interactive code cells
-        const codeCells = document.querySelectorAll(thebe_selector)
-        codeCells.forEach((codeCell, index) => {
-            const codeCellId = index => `codecell${index}`;
-            codeCell.id = codeCellId(index);
-            codeCellText = codeCell.querySelector(thebe_selector_input);
-            codeCellOutput = codeCell.querySelector(thebe_selector_output);
-
-            // Clean up the language to make it work w/ CodeMirror and add it to the cell
-            dataLanguage = detectLanguage(kernelName);
-
-            if (codeCellText) {
-                codeCellText.setAttribute('data-language', dataLanguage);
-                codeCellText.setAttribute('data-executable', 'true');
-
-                // If we had an output, insert it just after the `pre` cell
-                if (codeCellOutput) {
-                    $(codeCellOutput).attr("data-output", "");
-                    $(codeCellOutput).insertAfter(codeCellText);
-                }
-            }
-        });
-
-    // Init thebe
-    thebe.bootstrap();
+        configureThebe();
+        modifyDOMForThebe();
+        thebelab.bootstrap();
     });
 }
 

--- a/sphinx_thebe/_static/sphinx-thebe.js
+++ b/sphinx_thebe/_static/sphinx-thebe.js
@@ -3,86 +3,85 @@
  */
 
 var initThebe = () => {
-    // If Thebelab hasn't loaded, wait a bit and try again. This
-    // happens because we load ClipboardJS asynchronously.
-    if (window.thebelab === undefined) {
-        console.log("thebe not loaded, retrying...");
-        setTimeout(initThebe, 500)
-        return
-    }
+    // Load thebe dynamically so we can reduce page size
+    console.log("[sphinx-thebe]: Loading thebe from CDN...");
+    const script = document.createElement('script');
+    script.src = `https://unpkg.com/thebe@${THEBE_VERSION}/lib/index.js`;
+    document.head.appendChild(script);
 
-    console.log("Adding thebe to code cells...");
+    // Runs once the script has finished loading
+    script.addEventListener('load', () => {
+        // Load thebe config in case we want to update it as some point
+        console.log("[sphinx-thebe]: Initializing thebe...");
+        thebe_config = $('script[type="text/x-thebe-config"]')[0]
 
-    // Load thebe config in case we want to update it as some point
-    thebe_config = $('script[type="text/x-thebe-config"]')[0]
-
-
-    // If we already detect a Thebe cell, don't re-run
-    if (document.querySelectorAll('div.thebe-cell').length > 0) {
-        return;
-    }
-
-    // Update thebe buttons with loading message
-    $(".thebe-launch-button").each((ii, button) => {
-        button.innerHTML = `
-        <div class="spinner">
-            <div class="rect1"></div>
-            <div class="rect2"></div>
-            <div class="rect3"></div>
-            <div class="rect4"></div>
-        </div>
-        <span class="loading-text"></span>`;
-    })
-
-    // Set thebe event hooks
-    var thebeStatus;
-    thebelab.on("status", function (evt, data) {
-        console.log("Status changed:", data.status, data.message);
-
-        $(".thebe-launch-button ")
-        .removeClass("thebe-status-" + thebeStatus)
-        .addClass("thebe-status-" + data.status)
-        .find(".loading-text").html("<span class='launch_msg'>Launching from mybinder.org: </span><span class='status'>" + data.status + "</span>");
-
-        // Now update our thebe status
-        thebeStatus = data.status;
-
-        // Find any cells with an initialization tag and ask thebe to run them when ready
-        if (data.status === "ready") {
-            var thebeInitCells = document.querySelectorAll('.thebe-init, .tag_thebe-init');
-            thebeInitCells.forEach((cell) => {
-                console.log("Initializing Thebe with cell: " + cell.id);
-                cell.querySelector('.thebelab-run-button').click();
-            });
+        // If we already detect a Thebe cell, don't re-run
+        if (document.querySelectorAll('div.thebe-cell').length > 0) {
+            return;
         }
-    });
 
+        // Update thebe buttons with loading message
+        $(".thebe-launch-button").each((ii, button) => {
+            button.innerHTML = `
+            <div class="spinner">
+                <div class="rect1"></div>
+                <div class="rect2"></div>
+                <div class="rect3"></div>
+                <div class="rect4"></div>
+            </div>
+            <span class="loading-text"></span>`;
+        })
 
-    // Find all code cells, replace with Thebe interactive code cells
-    const codeCells = document.querySelectorAll(thebe_selector)
-    codeCells.forEach((codeCell, index) => {
-        const codeCellId = index => `codecell${index}`;
-        codeCell.id = codeCellId(index);
-        codeCellText = codeCell.querySelector(thebe_selector_input);
-        codeCellOutput = codeCell.querySelector(thebe_selector_output);
+        // Set thebe event hooks
+        var thebeStatus;
+        thebe.on("status", function (evt, data) {
+            console.log("Status changed:", data.status, data.message);
 
-        // Clean up the language to make it work w/ CodeMirror and add it to the cell
-        dataLanguage = detectLanguage(kernelName);
+            $(".thebe-launch-button ")
+            .removeClass("thebe-status-" + thebeStatus)
+            .addClass("thebe-status-" + data.status)
+            .find(".loading-text").html("<span class='launch_msg'>Launching from mybinder.org: </span><span class='status'>" + data.status + "</span>");
 
-        if (codeCellText) {
-            codeCellText.setAttribute('data-language', dataLanguage);
-            codeCellText.setAttribute('data-executable', 'true');
+            // Now update our thebe status
+            thebeStatus = data.status;
 
-            // If we had an output, insert it just after the `pre` cell
-            if (codeCellOutput) {
-                $(codeCellOutput).attr("data-output", "");
-                $(codeCellOutput).insertAfter(codeCellText);
+            // Find any cells with an initialization tag and ask thebe to run them when ready
+            if (data.status === "ready") {
+                var thebeInitCells = document.querySelectorAll('.thebe-init, .tag_thebe-init');
+                thebeInitCells.forEach((cell) => {
+                    console.log("Initializing Thebe with cell: " + cell.id);
+                    cell.querySelector('.thebelab-run-button').click();
+                });
             }
-        }
-    });
+        });
+
+
+        // Find all code cells, replace with Thebe interactive code cells
+        const codeCells = document.querySelectorAll(thebe_selector)
+        codeCells.forEach((codeCell, index) => {
+            const codeCellId = index => `codecell${index}`;
+            codeCell.id = codeCellId(index);
+            codeCellText = codeCell.querySelector(thebe_selector_input);
+            codeCellOutput = codeCell.querySelector(thebe_selector_output);
+
+            // Clean up the language to make it work w/ CodeMirror and add it to the cell
+            dataLanguage = detectLanguage(kernelName);
+
+            if (codeCellText) {
+                codeCellText.setAttribute('data-language', dataLanguage);
+                codeCellText.setAttribute('data-executable', 'true');
+
+                // If we had an output, insert it just after the `pre` cell
+                if (codeCellOutput) {
+                    $(codeCellOutput).attr("data-output", "");
+                    $(codeCellOutput).insertAfter(codeCellText);
+                }
+            }
+        });
 
     // Init thebe
-    thebelab.bootstrap();
+    thebe.bootstrap();
+    });
 }
 
 // Helper function to munge the language name

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -70,7 +70,7 @@ def test_sphinx_thebe(file_regression, sphinx_build):
     lb_text = "\n\n".join([ii.prettify() for ii in launch_buttons])
     file_regression.check(lb_text, basename="launch_buttons", extension=".html")
 
-    # Make sure thebe JS is not on pages (it should be loaded dynamically)
+    # Thebe JS should not be loaded by default (is loaded lazily)
     soup_chlg = BeautifulSoup(
         Path(sphinx_build.path_pg_chglg).read_text(), "html.parser"
     )
@@ -82,13 +82,8 @@ def test_always_load(file_regression, sphinx_build):
     sphinx_build.copy()
 
     # Basic build with defaults
-    sphinx_build.build(cmd=["-D", "thebe_config.always_load=false"])
+    sphinx_build.build(cmd=["-D", "thebe_config.always_load=true"])
 
-    # Thebe should be loaded on a page *with* the directive and not on pages w/o it
+    # Thebe should not 
     soup_ix = BeautifulSoup(Path(sphinx_build.path_pg_index).read_text(), "html.parser")
     assert "https://unpkg.com/thebe" in soup_ix.prettify()
-    # Changelog has no thebe button directive, so shouldn't have JS
-    soup_chlg = BeautifulSoup(
-        Path(sphinx_build.path_pg_chglg).read_text(), "html.parser"
-    )
-    assert "https://unpkg.com/thebe" not in soup_chlg.prettify()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -70,11 +70,11 @@ def test_sphinx_thebe(file_regression, sphinx_build):
     lb_text = "\n\n".join([ii.prettify() for ii in launch_buttons])
     file_regression.check(lb_text, basename="launch_buttons", extension=".html")
 
-    # Changelog has no thebe button directive, but should have the JS anyway
+    # Make sure thebe JS is not on pages (it should be loaded dynamically)
     soup_chlg = BeautifulSoup(
         Path(sphinx_build.path_pg_chglg).read_text(), "html.parser"
     )
-    assert "https://unpkg.com/thebe" in soup_chlg.prettify()
+    assert "https://unpkg.com/thebe" not in soup_chlg.prettify()
 
 
 def test_always_load(file_regression, sphinx_build):

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist = py37-sphinx3
 [testenv]
 usedevelop = true 
 
-[testenv:py{36,37,38}-sphinx{2,3}]
+[testenv:py{36,37,38,39}-sphinx{3,4}]
 extras = sphinx,testing
 deps =
     sphinx3: sphinx>=3,<4


### PR DESCRIPTION
### Description

This lazily loads the Thebe javascript bundle when the `initThebe` function is triggered (usually, when somebody clicks the "launch Thebe" button).

It does this by appending a `script` to the page header via javascript, rather than adding it to the Sphinx HTML bundle when it is created.

### Rationale

In most cases, people won't need Thebe loaded on a page because they'll only have one or two pages of their docs site that have Thebe-relevant content. Rather than loading Thebe each time, this will ensure it's loaded only when actively needed. It will take a bit longer to load when people click the button, but in most cases the size of the inputs/outputs loading will likely quickly be larger than the original thebe javascript payload, so this shouldn't hurt the UX much.

### Behavior changes

There's one default change with this PR: `thebe` will now be loaded lazily by default, whereas before it was loaded automatically on all pages by default.

closes https://github.com/executablebooks/sphinx-thebe/issues/34 
closes https://github.com/executablebooks/jupyter-book/issues/1014
closes https://github.com/executablebooks/sphinx-thebe/issues/32