### PR TITLE
MAINT: Add missing space between launch button tag elements

### DIFF
--- a/sphinx_thebe/__init__.py
+++ b/sphinx_thebe/__init__.py
@@ -180,7 +180,7 @@ class ThebeButtonNode(nodes.Element):
     def html(self):
         text = self["text"]
         return (
-            '<button title="{text}" class="thebelab-button thebe-launch-button"'
+            '<button title="{text}" class="thebelab-button thebe-launch-button" '
             'onclick="initThebe()">{text}</button>'.format(text=text)
         )
 


### PR DESCRIPTION
- While browsing the source to a generated page, I saw an HTML warning
  about a missing space between two of the button attributes.  This
  adds it.
- Review: quick look/automerge
