### PR TITLE
RELEASE: v0.1.0 (second try)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## v0.1.0
+
+([full changelog](https://github.com/executablebooks/sphinx-thebe/compare/v0.0.10...4d1a60c5126ce633b1a36de43b4990b2f4d08730))
+
+**Lazy load thebe javascript** [#41](https://github.com/executablebooks/sphinx-thebe/pull/41) ([@choldgraf](https://github.com/choldgraf))
+
+`thebe` will now "lazily load" its javascript only when a bootstrap button is pressed, rather than loading the Javascript on each page.
+This saves on bandwidth and pageload speed, since Thebe is generally _not_ used on a page even if it _could_ be used.

--- a/sphinx_thebe/__init__.py
+++ b/sphinx_thebe/__init__.py
@@ -9,7 +9,7 @@ from docutils.parsers.rst import Directive, directives
 from docutils import nodes
 from sphinx.util import logging
 
-__version__ = "0.0.10"
+__version__ = "0.1.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This once again generates a release, will try to spot-check why github actions aren't being run.

Also bumps up to `0.1` since this is technically a feature release, and we're trying to follow semver here so we should just start using minor versions.