### PR TITLE
FIX: Kernelspec dict error

### DIFF
--- a/sphinx_thebe/__init__.py
+++ b/sphinx_thebe/__init__.py
@@ -108,7 +108,10 @@ def update_thebe_context(app, doctree, docname):
     kernel_name = meta.get("thebe-kernel")
     if kernel_name is None:
         if meta.get("kernelspec"):
-            kernel_name = json.loads(meta["kernelspec"]).get("name")
+            if isinstance(meta.get("kernelspec"), str):
+                kernel_name = json.loads(meta["kernelspec"]).get("name")
+            else:
+                kernel_name = meta["kernelspec"].get("name")
         else:
             kernel_name = "python3"
 


### PR DESCRIPTION
This fixes a bug that pops up when the kernelspec that is read by myst-nb is passed as a dictionary instead of a JSON string. This seems to happen only under certain circumstances, I'm not sure when, so this PR handles both cases now:

Here's what the error was looking like:

```
Handler <function update_thebe_context at 0x7f2eb5effca0> for event 'doctree-resolved' threw an exception (exception: the JSON object must be str, bytes or bytearray, not dict)
```