### PR TITLE
MAINT: update testing against sphinx6, drop sphinx3

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,12 @@
 name: continuous-integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_call:
 
 jobs:
   docs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+# This will run every time a tag is created and pushed to the repository.
+# It calls our tests workflow via a `workflow_call`, and if tests pass
+# then it triggers our upload to PyPI for a new release.
+name: Publish to PyPI
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+  publish:
+    name: publish
+    needs: [tests] # require tests to pass before deploy runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Build package
+        run: |
+          python -m pip install -U pip build
+          python -m build
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.6.4
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,26 +28,3 @@ jobs:
     - name: Run tests
       run: |
         pytest
-
-  publish:
-
-    name: Publish to PyPi
-    needs: [docs]
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
-        with:
-          python-version: "3.8"
-      - name: Build package
-        run: |
-          pip install build
-          python -m build
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.1.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_KEY }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ release = ""
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_nb", "sphinx_copybutton", "sphinx_panels", "sphinx_thebe"]
+extensions = ["myst_nb", "sphinx_copybutton", "sphinx_design", "sphinx_thebe"]
 
 thebe_config = {
     "repository_url": "https://github.com/binder-examples/jupyter-stacks-datascience",
@@ -70,7 +70,8 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
+# Not recommended sphinx >=5. https://github.com/sphinx-doc/sphinx/issues/10474
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,21 +102,6 @@ html_theme_options = {
     "launch_buttons": {"thebelab": True},
 }
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ["_static"]
-
-# Custom sidebar templates, must be a dictionary that maps document names
-# to template names.
-#
-# The default sidebars (for documents that don't match any pattern) are
-# defined by theme itself.  Builtin themes are using these templates by
-# default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
-# 'searchbox.html']``.
-#
-# html_sidebars = {}
-
 # CopyButton configuration
 copybutton_prompt_text = ">>> "
 # Switches for testing but shouldn't be activated in the live docs
@@ -124,8 +109,6 @@ copybutton_prompt_text = ">>> "
 # copybutton_remove_prompts = False
 # copybutton_image_path = "test/TEST_COPYBUTTON.png"
 # copybutton_selector = "div"
-
-panels_add_bootstrap_css = False
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -36,8 +36,10 @@ code and Thebe will detect it.
 
 For example, the following code:
 
-``````{tabbed} MyST Markdown
-`````
+``````{tab-set}
+
+`````{tab-item} Myst Markdown
+
 ````{container} thebe
 ```{code-block} r
 print("hi")
@@ -47,10 +49,11 @@ print("hi")
 "hi"
 ```
 ````
-`````
-``````
 
-``````{tabbed} reStructuredText
+`````
+
+`````{tab-item} reStructuredText
+
 ```{code-block} rst
 .. container:: thebe
    .. code-block:: r
@@ -59,6 +62,9 @@ print("hi")
    .. container:: output
       "hi"
 ```
+
+`````
+
 ``````
 
 Defines a *parent container* in which we'll put both code and the output of the
@@ -146,21 +152,26 @@ qplot(hp, mpg, data=mtcars, shape=am, color=am,
 You can tag code blocks to run as soon as the kernel is ready (i.e., without any user input)
 by adding the `thebe-init` class to the code blocks. For example:
 
-`````{tabbed} MyST Markdown
-````
+`````{tab-set}
+
+````{tab-item} MyST Markdown
 ```{code-block}
 :class: thebe, thebe-init
 print("hi")
 ```
 ````
-`````
-`````{tabbed} reStructuredText
+
+````{tab-item} reStructuredText
+
 ```rst
 .. code-block::
    :class: thebe, thebe-init
    
    print("hi")
 ```
+
+````
+
 `````
 
 These code blocks will be run automatically once the kernel is ready, and their outputs

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    install_requires=["sphinx>=4,<6"],
+    install_requires=["sphinx>=4,<7"],
     extras_require={
         "sphinx": [
             "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -47,14 +47,14 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    install_requires=["sphinx>=3.5,<5"],
+    install_requires=["sphinx>=4,<6"],
     extras_require={
         "sphinx": [
             "matplotlib",
             "myst-nb",
             "sphinx-book-theme",
             "sphinx-copybutton",
-            "sphinx-panels",
+            "sphinx-design",
         ],
         "testing": ["matplotlib", "pytest", "pytest-regressions", "beautifulsoup4"],
     },

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "sphinx": [
             "matplotlib",
             "myst-nb",
-            "sphinx-book-theme",
+            "sphinx-book-theme>=0.4.0rc1",
             "sphinx-copybutton",
             "sphinx-design",
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -11,16 +11,17 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py39-sphinx4
+envlist = py39-sphinx5
 
 [testenv]
 usedevelop = true 
+passenv = TERM  # To make terminal coloring / other variables pass through
 
-[testenv:py{38,39}-sphinx{4,5}]
+[testenv:py{38,39}-sphinx{5,6}]
 extras = sphinx,testing
 deps =
-    sphinx4: sphinx>=4,<5
     sphinx5: sphinx>=5,<6
+    sphinx6: sphinx>=6,<7
 commands = pytest {posargs}
 
 [testenv:docs-{update,clean}]

--- a/tox.ini
+++ b/tox.ini
@@ -11,16 +11,16 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py39-sphinx3
+envlist = py39-sphinx4
 
 [testenv]
 usedevelop = true 
 
-[testenv:py{37,38,39}-sphinx{3,4}]
+[testenv:py{38,39}-sphinx{4,5}]
 extras = sphinx,testing
 deps =
-    sphinx3: sphinx>=3,<4
     sphinx4: sphinx>=4,<5
+    sphinx5: sphinx>=5,<6
 commands = pytest {posargs}
 
 [testenv:docs-{update,clean}]


### PR DESCRIPTION
This PR updates the testing infrastructure to test against `sphinx4` and `sphinx5` and `sphinx6` (dropping `sphinx3`). 

It also replaces `sphinx-panels` with `sphinx-design` as `sphinx-panels` is now deprecated. 